### PR TITLE
Enh fix socket error interrupted

### DIFF
--- a/amqpy/method_io.py
+++ b/amqpy/method_io.py
@@ -179,6 +179,7 @@ class MethodReader:
         except socket.error as e:
             if get_errno(e) == errno.EAGAIN:
                 raise Timeout()
+            raise
         finally:
             if orig_timeout != timeout:
                 self.sock.settimeout(orig_timeout)


### PR DESCRIPTION
Detected because I got AssertionError (thanks to it ;)) when I interrupt a drain_events().