### PR TITLE
Enh/Fix: make the heartbeat thread actively verify the last_heartbeat…

### DIFF
--- a/amqpy/transport.py
+++ b/amqpy/transport.py
@@ -41,7 +41,7 @@ class Transport(metaclass=ABCMeta):
         #: :type: datetime.datetime
         self.last_heartbeat_sent = None
         #: :type: datetime.datetime
-        self.last_heartbeat_received = None
+        self.last_heartbeat_received = datetime.datetime.now()
 
         self.last_heartbeat_sent_monotonic = 0.0
 


### PR DESCRIPTION
…_received

If server fails to send us its heartbeat, we should assume it's dead/gone.

NB: The heartbeat thread doesn't execute drain_events() calls,
so the user - if he activated the heartbeat - must know that he should
 frequently (at least once every connection._heartbeat_final) call
 drain_events() so that the server heartbeats are read and accounted.