### PR TITLE
Support login methods other than AMQPLAIN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ venv
 # generated documentation
 docs/build
 
+# vim
+*.swp
+
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/amqpy/connection.py
+++ b/amqpy/connection.py
@@ -21,6 +21,7 @@ from .transport import create_transport
 from . import spec
 from .spec import method_t
 from .concurrency import synchronized
+from .login import login_responses
 
 __all__ = ['Connection']
 
@@ -154,9 +155,7 @@ class Connection(AbstractChannel):
         self.wait(spec.Connection.Start)
 
         # create 'login response' to send to server
-        login_response = AMQPWriter()
-        login_response.write_table({'LOGIN': self._userid, 'PASSWORD': self._password})
-        login_response = login_response.getvalue()[4:]  # skip the length
+        login_response = login_responses[self._login_method](self._userid, self._password)
 
         # reply with 'start-ok' and connection parameters
         # noinspection PyArgumentList

--- a/amqpy/login.py
+++ b/amqpy/login.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+__metaclass__ = type
+
+from .serialization import AMQPWriter
+
+__all__ = ['login_responses']
+
+def login_response_amqplain(userid, password):
+    response = AMQPWriter()
+    response.write_table({'LOGIN': userid, 'PASSWORD': password})
+    return response.getvalue()[4:]  # skip the length
+
+login_responses = {
+    'AMQPLAIN': login_response_amqplain,
+}

--- a/amqpy/login.py
+++ b/amqpy/login.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 __metaclass__ = type
 
+import six
+import io
+from struct import pack
+
 from .serialization import AMQPWriter
 
 __all__ = ['login_responses']
@@ -11,6 +15,24 @@ def login_response_amqplain(userid, password):
     response.write_table({'LOGIN': userid, 'PASSWORD': password})
     return response.getvalue()[4:]  # skip the length
 
+def login_response_plain(userid, password):
+    """https://tools.ietf.org/html/rfc4616"""
+    response = io.BytesIO()
+    if isinstance(userid, six.string_types):
+        userid = userid.encode('utf-8')
+    if isinstance(password, six.string_types):
+        password = password.encode('utf-8')
+    # authzid
+    response.write(userid)
+    response.write(pack('B', 0))
+    # authcid
+    response.write(userid)
+    response.write(pack('B', 0))
+    # passwd
+    response.write(password)
+    return response.getvalue()
+
 login_responses = {
     'AMQPLAIN': login_response_amqplain,
+    'PLAIN': login_response_plain,
 }


### PR DESCRIPTION
There's an issue between amqpy and the Qpid Java Broker (which supports AMQP 0-9-1, unlike the Qpid C++ Broker, which only supports AMQP 0-10 or 1.0). Setting `login_method` to `PLAIN` just changes what amqpy advertises to the server, so it still sends an AMQPLAIN formatted SASL response, which (unsurprisingly) doesn't work.

This PR causes amqpy to actually change the response format when requested, or raise a `KeyError` if the specified `login_method` isn't supported.