### PR TITLE
Added support for AMQP connection string

### DIFF
--- a/amqpy/connection.py
+++ b/amqpy/connection.py
@@ -126,7 +126,7 @@ class Connection(AbstractChannel):
             port = parts.port or 5672
             userid = unquote(parts.username or '') or 'guest'
             password = unquote(parts.password or '') or 'guest'
-            virtual_host = unquote(parts.path or '/')
+            virtual_host = unquote(parts.path[1:] or '/')
 
         # save connection parameters
         self._host = host

--- a/amqpy/connection.py
+++ b/amqpy/connection.py
@@ -2,7 +2,7 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from future.moves.urllib.parse import urlparse, urlencode
+from future.moves.urllib.parse import urlparse, urlencode, unquote
 
 __metaclass__ = type
 import logging

--- a/amqpy/connection.py
+++ b/amqpy/connection.py
@@ -123,9 +123,9 @@ class Connection(AbstractChannel):
         if host.startswith('amqp://'):
             parts = urlparse("http://" + host[7:])
             host = unquote(parts.hostname or '') or None
-            port = parts.port
-            userid = unquote(parts.username or '') or None
-            password = unquote(parts.password or '') or None
+            port = parts.port or 5672
+            userid = unquote(parts.username or '') or 'guest'
+            password = unquote(parts.password or '') or 'guest'
             virtual_host = unquote(parts.path or '/')
 
         # save connection parameters

--- a/amqpy/connection.py
+++ b/amqpy/connection.py
@@ -2,7 +2,7 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from urlparse import urlparse, unquote
+from future.moves.urllib.parse import urlparse, urlencode
 
 __metaclass__ = type
 import logging

--- a/amqpy/connection.py
+++ b/amqpy/connection.py
@@ -2,7 +2,7 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from future.moves.urllib.parse import urlparse, urlencode, unquote
+from future.moves.urllib.parse import urlparse, unquote
 
 __metaclass__ = type
 import logging

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,10 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'tests', 'tests.*']),
     package_data=package_data,
     setup_requires=['six>=1.0'],
-    install_requires=['six>=1.0'],
+    install_requires=[
+        'six>=1.0',
+        'future>=0.16.0',
+    ],
     tests_require=['pytest>=2.6'],
     classifiers=classifiers,
     keywords=keywords


### PR DESCRIPTION
This patch adds support for AMQP connection string passed as the `host` parameter when creating a `Connection`. This is linked to issue #33 but does not contain cluster support.
